### PR TITLE
Nixos migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This script will install various Nix packages and flatpaks for the system, as well as enable a cpu scheduler that may improve battery life. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch, and also docked to the official Steam Deck Dock.
 It is recommended to restart after the script finishes, then boot back into Desktop Mode and run any installers that the script mentioned that it put on your Desktop...if you're interested in those.
 
-This script now assumes you're running a version of SteamOS with the `/nix` directory included by default. This means SteamOS 3.5 or newer.
+This script now assumes you're running a version of SteamOS with the `/nix` directory included by default. This means SteamOS 3.5.5 or newer.
 
 ## Usage
 First, boot into Desktop Mode. Next, let's open up the Konsole from the Steam Deck application menu with the D symbol at the bottom left of Desktop mode's desktop. Then paste these commands one line at a time to run the script:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Deck Script For Working via Steam Deck
-This script will install some dev programs and temporarily disable the read-only filesystem so that you can work with terminal development tools. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch.
+This script will install some dev programs and temporarily disable the read-only filesystem so that you can work with terminal development tools. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch, and also docked to the official Steam Deck Dock.
 It is recommended to restart after the script finishes, then boot back into Desktop Mode and run any installers that the script mentioned that it put on your Desktop.
 
+This script now assumes you're running a version of SteamOS with the `/nix` directory included by default.
+
 ## Usage
-First, boot into Desktop Mode. Next, let's open up the Konsole from the Steam Deck application menu at the bottom left of Desktop mode. Then paste these commands one line at a time to run the script:
+First, boot into Desktop Mode. Next, let's open up the Konsole from the Steam Deck application menu with the D symbol at the bottom left of Desktop mode's desktop. Then paste these commands one line at a time to run the script:
 ```
 git clone https://github.com/al12gamer/deckscript.git
 cd deckscript
@@ -12,8 +14,9 @@ bash deckscript.sh
 Be sure to hit enter after pasting each line.
 ## Programs Installed
 This Script will install the following programs:
-+ Package managers: yay
++ Package managers: nix, pacman
 + Flatpaks: Boxes, Brave, Protonup-QT, Codium, Lutris, Firefox, Dophin, Yuzu, Element messenger
++ Nix Packages: 
 + Pacman Packages: vim, neofetch, btop++ (from aur), base devel packages, ansible, ansible-core, vim-ansible, python3-pip, jotta-cli (from aur)
 + Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12)
 ## Issues?

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Be sure to hit enter after pasting each line.
 This Script will install the following programs:
 + Package managers: Nix, Flatpak
 + Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu, SyncThingy
-+ Nix Packages: Boxes, Brave, Element messenger, Firefox, VSCodium, Gnome-Boxes, btop, Jotta-CLI backup utility
++ Nix Packages: fastfetch, Brave, Element messenger, Firefox, VSCodium, Gnome-Boxes, btop, Jotta-CLI backup utility
 + Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12), [EmuDeck Installer](https://emudeck.github.io/)
 ## Issues?
 If you have any problems with this script or any suggestions, feel free to [open an issue here](https://github.com/al12gamer/deckscript/issues)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Be sure to hit enter after pasting each line.
 ## Programs Installed
 This Script will install the following programs:
 + Package managers: Nix, Flatpak
-+ Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu
++ Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu, SyncThingy
 + Nix Packages: Boxes, Brave, Element messenger, Firefox, VSCodium, Gnome-Boxes, btop, Jotta-CLI backup utility
 + Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12), [EmuDeck Installer](https://emudeck.github.io/)
 ## Issues?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Deck Script For Working via Steam Deck
-This script will install some dev programs and temporarily disable the read-only filesystem so that you can work with terminal development tools. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch, and also docked to the official Steam Deck Dock.
+This script will install various Nix packages and flatpaks for the system, as well as enable a cpu scheduler that may improve battery life. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch, and also docked to the official Steam Deck Dock.
 It is recommended to restart after the script finishes, then boot back into Desktop Mode and run any installers that the script mentioned that it put on your Desktop...if you're interested in those.
 
 This script now assumes you're running a version of SteamOS with the `/nix` directory included by default. This means SteamOS 3.5 or newer.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ bash deckscript.sh
 Be sure to hit enter after pasting each line.
 ## Programs Installed
 This Script will install the following programs:
-+ Package managers: nix, pacman
-+ Flatpaks: Boxes, Brave, Protonup-QT, Codium, Lutris, Firefox, Dophin, Yuzu, Element messenger
-+ Nix Packages: 
-+ Pacman Packages: vim, neofetch, btop++ (from aur), base devel packages, ansible, ansible-core, vim-ansible, python3-pip, jotta-cli (from aur)
++ Package managers: nix, flatpak
++ Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu, 
++ Nix Packages: Boxes, Brave, Element messenger, Firefox, VSCodium, Gnome-Boxes, btop, Jotta-CLI backup utility
 + Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12)
 ## Issues?
 If you have any problems with this script or any suggestions, feel free to [open an issue here](https://github.com/al12gamer/deckscript/issues)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Deck Script For Working via Steam Deck
 This script will install some dev programs and temporarily disable the read-only filesystem so that you can work with terminal development tools. Note that this script was made from Desktop Mode on my personal Steam Deck plugged into a NexDock Touch, and also docked to the official Steam Deck Dock.
-It is recommended to restart after the script finishes, then boot back into Desktop Mode and run any installers that the script mentioned that it put on your Desktop.
+It is recommended to restart after the script finishes, then boot back into Desktop Mode and run any installers that the script mentioned that it put on your Desktop...if you're interested in those.
 
-This script now assumes you're running a version of SteamOS with the `/nix` directory included by default.
+This script now assumes you're running a version of SteamOS with the `/nix` directory included by default. This means SteamOS 3.5 or newer.
 
 ## Usage
 First, boot into Desktop Mode. Next, let's open up the Konsole from the Steam Deck application menu with the D symbol at the bottom left of Desktop mode's desktop. Then paste these commands one line at a time to run the script:
@@ -14,9 +14,9 @@ bash deckscript.sh
 Be sure to hit enter after pasting each line.
 ## Programs Installed
 This Script will install the following programs:
-+ Package managers: nix, flatpak
-+ Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu, 
++ Package managers: Nix, Flatpak
++ Flatpaks: Protonup-QT, Lutris, Dolphin, Yuzu
 + Nix Packages: Boxes, Brave, Element messenger, Firefox, VSCodium, Gnome-Boxes, btop, Jotta-CLI backup utility
-+ Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12)
++ Add-ons: [Retroarch Core Downloader](https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh), [CryoUtilities](https://github.com/CryoByte33/steam-deck-utilities), [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader), [Pi webcam scripts](https://github.com/geerlingguy/pi-webcam), [Prerequisites for Playing Ship of Harkinian mod](https://github.com/al12gamer/deckscript/issues/12), [EmuDeck Installer](https://emudeck.github.io/)
 ## Issues?
 If you have any problems with this script or any suggestions, feel free to [open an issue here](https://github.com/al12gamer/deckscript/issues)

--- a/SoH.sh
+++ b/SoH.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 cd
 echo "Creating an SoH folder for you, and adding the required ROMS to it from Archive.org"
-sleep 2
+sleep 3
 mkdir SoH
 cd SoH
 wget https://archive.org/download/ship-of-harkinian/ZELOOTD.zip
 unzip ZELOOTD.zip
 cd
 echo "Finished, your files are in the SoH folder."
-sleep 2
-echo "...if you would like to download Ship of Harkinian, we will now open up their web page so you can join their discord"
-sleep 4
+sleep 3
+echo "Opening the Releases page for SoH"
+sleep 1
 firefox https://github.com/HarbourMasters/Shipwright/releases/

--- a/SoH.sh
+++ b/SoH.sh
@@ -11,4 +11,4 @@ echo "Finished, your files are in the SoH folder."
 sleep 2
 echo "...if you would like to download Ship of Harkinian, we will now open up their web page so you can join their discord"
 sleep 4
-firefox https://discord.com/invite/shipofharkinian
+firefox https://github.com/HarbourMasters/Shipwright/releases/

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -21,7 +21,7 @@ echo ********************************
 sleep 4
 sudo chown deck:deck /nix
 sh <(curl -L https://nixos.org/nix/install) --no-daemon
-nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixpkgs.jotta-cli
+nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixpkgs.jotta-cli nixpkgs.fastfetch
 cd
 flatpak update --appstream
 flatpak update -y

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -19,7 +19,7 @@ echo "Now we'll install the Nix package manager and grab some programs"
 echo ********************************
 sleep 4
 sh <(curl -L https://nixos.org/nix/install) --no-daemon
-nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixos.jotta-cli
+nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixpkgs.jotta-cli
 cd
 flatpak update --appstream
 flatpak update -y
@@ -43,7 +43,7 @@ chmod +x decky_installer.desktop
 cd
 echo "The most recent CryoUtilities installer and Decky Loader installer will now be on your desktop. Install them after a reboot by double-clicking them and running through the scripts one at a time"
 sleep 4
-echo "If you would like to download Ship of Harkinian, a comprehensive Ocarina of Time mod, run SoH.sh from the deckscript folder after a reboot."
+echo "If you would like to download Ship of Harkinian, a comprehensive Ocarina of Time mod, run SoH.sh from the deckscript folder after a reboot. It will open Firefox to their download page for their newest release."
 sleep 4
 ## should be done at this point, but might need furher tweaking depending on what you want to install
 cd

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -4,7 +4,7 @@ echo ********************************
 echo ********************************
 ## First let's change that password
 echo ********************************
-echo "Please change your Deck admin password if you haven't already, otherwise this won't work"
+echo "Please change your Deck admin password if you haven't already, otherwise this may not work"
 echo ********************************
 sleep 3
 echo "Installing a cpu auto scheduler"

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -30,7 +30,7 @@ sudo pacman-key --init
 sudo pacman-key --populate archlinux
 sudo locale-gen
 sudo pacman -Sy archlinux-keyring && pacman -Su
-sudo pacman --noconfirm -Syyu git go base-devel lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader neofetch vim cmake glibc ansible python3-pip unzip
+sudo pacman --noconfirm -Syyu git go base-devel lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader vim nix
 ## install yay for an AUR helper, also grab btop
 cd
 sudo pacman --noconfirm -S cmake pkg-config glibc gcc libarchive linux-api-headers ansible vim-ansible ansible-core

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -28,8 +28,8 @@ flatpak install -y pupgui2 yuzu dolphin
 cd
 cd Desktop
 wget https://github.com/icculus/twisty-little-utilities/blob/main/steamdeck-retroarch-download-all-cores.sh
-bash steamdeck-retroarch-download-all-cores.sh
-echo "If you had retroarch installed via Steam, all the cores are now updated"
+chmod +x steamdeck-retroarch-download-all-cores.sh
+echo "If you had retroarch installed via Steam, feel free to run the download-all-cores file on your desktop in the future"
 sleep 2
 cd
 ## git clone the pi webcam directory to desktop, for reference point when installing pi webcam stuff

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -5,8 +5,9 @@ echo ********************************
 ## First let's change that password
 echo ********************************
 echo "Please change your Deck admin password if you haven't already, otherwise this may not work"
+echo "You can change the admin password by typing passwd and hitting enter in your Konsole terminal"
 echo ********************************
-sleep 3
+sleep 4
 echo "Installing a cpu auto scheduler"
 mkdir cpufreq
 cd cpufreq
@@ -18,6 +19,7 @@ echo ********************************
 echo "Now we'll install the Nix package manager and grab some programs"
 echo ********************************
 sleep 4
+sudo chown deck:deck /nix
 sh <(curl -L https://nixos.org/nix/install) --no-daemon
 nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixpkgs.jotta-cli
 cd

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -45,6 +45,12 @@ echo "The most recent CryoUtilities installer and Decky Loader installer will no
 sleep 4
 echo "If you would like to download Ship of Harkinian, a comprehensive Ocarina of Time mod, run SoH.sh from the deckscript folder after a reboot. It will open Firefox to their download page for their newest release."
 sleep 4
+## emudeck
+cd
+cd Desktop
+wget https://www.emudeck.com/EmuDeck.desktop
+echo "EmuDeck's installer has been also downloaded to the desktop"
+sleep 4
 ## should be done at this point, but might need furher tweaking depending on what you want to install
 cd
 sleep 2

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -23,7 +23,7 @@ nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-b
 cd
 flatpak update --appstream
 flatpak update -y
-flatpak install -y pupgui2 yuzu dolphin
+flatpak install -y pupgui2 yuzu dolphin com.github.zocker_160.SyncThingy
 ## pull most recent Retroarch cores, if you have retroarch installed
 cd
 cd Desktop

--- a/deckscript.sh
+++ b/deckscript.sh
@@ -2,7 +2,6 @@
 echo "HELLO! Welcome to the Script!"
 echo ********************************
 echo ********************************
-echo "Now to install some things..." 
 ## First let's change that password
 echo ********************************
 echo "Please change your Deck admin password if you haven't already, otherwise this won't work"
@@ -14,30 +13,17 @@ cd cpufreq
 wget https://github.com/TheRealAlexV/steamdeck-scripts/blob/main/functions/auto-cpufreq.sh
 bash auto-cpufreq.sh
 cd
-## Install multilib stuff and disable readonly filesystem
+## Install the previously pacman packages through Nix - install Nix package manager first
 echo ********************************
-echo "Now we'll install and update terminal programs along with flatpak apps"
+echo "Now we'll install the Nix package manager and grab some programs"
 echo ********************************
-sleep 5
-sudo steamos-readonly disable
+sleep 4
+sh <(curl -L https://nixos.org/nix/install) --no-daemon
+nix-env -iA nixpkgs.firefox nixpkgs.brave nixpkgs.vscodium nixpkgs.gnome.gnome-boxes nixpkgs.btop nixos.jotta-cli
+cd
 flatpak update --appstream
 flatpak update -y
-flatpak install -y codium boxes lutris pupgui2 brave firefox im.riot.Riot
-## also grab yuzu and dolphin
-flatpak install -y yuzu dolphin
-## pupgui2 is protonup-qt, also we may need to initialize pacman keys here as that helped on my deck running SteamOS 3.4.6
-sudo pacman-key --init
-sudo pacman-key --populate archlinux
-sudo locale-gen
-sudo pacman -Sy archlinux-keyring && pacman -Su
-sudo pacman --noconfirm -Syyu git go base-devel lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader vim nix
-## install yay for an AUR helper, also grab btop
-cd
-sudo pacman --noconfirm -S cmake pkg-config glibc gcc libarchive linux-api-headers ansible vim-ansible ansible-core
-git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
-yay -S --noconfirm btop-git
-## also install jotta-cli from aur to backup and sync certain things - for example I've added my Switch keys to the sync folder
-yay -S --noconfirm jotta-cli
+flatpak install -y pupgui2 yuzu dolphin
 ## pull most recent Retroarch cores, if you have retroarch installed
 cd
 cd Desktop
@@ -48,6 +34,7 @@ sleep 2
 cd
 ## git clone the pi webcam directory to desktop, for reference point when installing pi webcam stuff
 git clone https://github.com/geerlingguy/pi-webcam.git
+## Make sure the CryoUtilities and Decky installers are ready to go
 cd Desktop
 wget --content-disposition https://raw.githubusercontent.com/CryoByte33/steam-deck-utilities/main/InstallCryoUtilities.desktop
 wget --content-disposition https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/decky_installer.desktop
@@ -60,6 +47,5 @@ echo "If you would like to download Ship of Harkinian, a comprehensive Ocarina o
 sleep 4
 ## should be done at this point, but might need furher tweaking depending on what you want to install
 cd
-sudo steamos-readonly enable
 sleep 2
 echo "Good to go, reboot when ready!"


### PR DESCRIPTION
This will probably be a long-running pull request to eventually move all extra yay or pacman packages I added to my Deck previously, to the nix package manager.

Per [this comment here](https://github.com/NixOS/nix/issues/7173#issuecomment-1604717502), it has been rumored that the Steam Deck will include a `/nix` directory by default in the future. In learning about NixOS, I want to move more immutable installs to use nix packages.